### PR TITLE
fix: 将 actions/upload-artifact 从 v3 升级到 v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         sed -i 's/moduleDescription = "/moduleDescription = "(${{ github.event.inputs.package_name }}) /g' module.gradle
         sed -i "s/com.game.packagename/${{ github.event.inputs.package_name }}/g" module/src/main/cpp/game.h
         ./gradlew :module:assembleRelease
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: zygisk-il2cppdumper
         path: out/magisk_module_release/


### PR DESCRIPTION
- 将已弃用的 `actions/upload-artifact@v3` 替换为 `actions/upload-artifact@v4`
- 解决因 GitHub 在 2025-01-30 弃用 v3 导致的工作流失败问题
- 确保兼容最新 GitHub Actions 运行器功能

参考：GitHub 弃用公告 https://github.blog/changelog/2024-01-30-github-actions-upload-artifact-v3-will-no-longer-be-supported-after-2025-01-30/