### PR TITLE
Change upload-artifact version v3 to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         sed -i 's/moduleDescription = "/moduleDescription = "(${{ github.event.inputs.package_name }}) /g' module.gradle
         sed -i "s/com.game.packagename/${{ github.event.inputs.package_name }}/g" module/src/main/cpp/game.h
         ./gradlew :module:assembleRelease
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: zygisk-il2cppdumper
         path: out/magisk_module_release/


### PR DESCRIPTION
Upload artifact version 3 of Git Actions ended support on January 30, 2025, and version 4 is required.
If you do not change the version information of build.yml, the build is failed.

> refer : [https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/](url)

> build error : This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.